### PR TITLE
fix: use debian bullseye-slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # Identify the maintainer of an image
 LABEL maintainer="contact@openchia.io"


### PR DESCRIPTION
Use `debian:bullseye-slim`.

With `debian:stable-slim` include Python 3.11 and I've a problem during install dependencies.
Bullseye uses Python 3.9 and I don't have problems.