### PR TITLE
fix: support rc and dev Chia versions

### DIFF
--- a/pool/pool.py
+++ b/pool/pool.py
@@ -1734,7 +1734,7 @@ class Pool:
             chia_version = req_metadata.get_chia_version()
         if self.testnet:
             pass
-        elif not chia_version or (chia_version < Version('2.5.1')):
+        elif not chia_version or (chia_version.release < Version('2.5.1').release):
             await self.partials.add_partial(
                 partial.payload,
                 req_metadata,


### PR DESCRIPTION
Support users with rc/dev Chia version like `2.5.1rc1.dev16`. The solution use `release` of `Version()`.

The current code return `2.5.1rc2`, and fail to compare.

```
return Version('.'.join(v.split('Chia Blockchain v.', 1)[-1].split('-')[0].split('.', 3)[:3]))
```

Tests:

```
>>> print('rejected' if Version('2.5.1rc2') < Version('2.5.1') else 'success')
rejected
>>> print('rejected' if Version('2.5.1rc2').release < Version('2.5.1').release else 'success')
success
>>> print('rejected' if Version('2.5.0rc2').release < Version('2.5.1').release else 'success')
rejected
```